### PR TITLE
BaseSelfDefProcess接口新增CLIENT_METHOD字段

### DIFF
--- a/user-extend-client/src/main/java/com/alibaba/csb/BaseSelfDefProcess.java
+++ b/user-extend-client/src/main/java/com/alibaba/csb/BaseSelfDefProcess.java
@@ -78,6 +78,10 @@ public interface BaseSelfDefProcess {
      */
     String BACKEND_METHOD = "backend_method";
     /**
+     * 客户端请求数据面的http方法：POST、GET等
+     */
+    String CLIENT_METHOD = "client_method";
+    /**
      * 请求后端业务服务的http query：map《String,List《String》》
      */
     String REQUEST_HTTP_QUERYS = "request_http_querys";


### PR DESCRIPTION
CSB 自定义扩展插件传入的参数增加原始请求方式CLIENT_METHOD字段，当客户端向CSB数据面的请求方式与后端服务支持的请求方式不同时，可以实现BeforeSend2BackendHttp接口自定义是否继续执行。